### PR TITLE
Permit leading whitespace in IAM policies by normalizing before checking structure

### DIFF
--- a/aws/validators.go
+++ b/aws/validators.go
@@ -652,17 +652,19 @@ func validateJsonString(v interface{}, k string) (ws []string, errors []error) {
 
 func validateIAMPolicyJson(v interface{}, k string) (ws []string, errors []error) {
 	// IAM Policy documents need to be valid JSON, and pass legacy parsing
-	value := v.(string)
-	if len(value) < 1 {
+	vString := v.(string)
+	if len(vString) < 1 {
 		errors = append(errors, fmt.Errorf("%q contains an invalid JSON policy", k))
 		return
 	}
-	if value[:1] != "{" {
-		errors = append(errors, fmt.Errorf("%q contains an invalid JSON policy", k))
-		return
-	}
-	if _, err := structure.NormalizeJsonString(v); err != nil {
+	vNormalized, err := structure.NormalizeJsonString(v)
+	if err != nil {
 		errors = append(errors, fmt.Errorf("%q contains an invalid JSON: %s", k, err))
+		return
+	}
+	if vNormalized[:1] != "{" {
+		errors = append(errors, fmt.Errorf("%q contains an invalid JSON policy", k))
+		return
 	}
 	return
 }

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -797,10 +797,6 @@ func TestValidateIAMPolicyJsonString(t *testing.T) {
 			Value:    ``,
 			ErrCount: 1,
 		},
-		{
-			Value:    `    {"xyz": "foo"}`,
-			ErrCount: 1,
-		},
 	}
 
 	for _, tc := range invalidCases {


### PR DESCRIPTION
Fixes #1873

Changes proposed in this pull request:

* Normalize IAM policy json before testing structure
